### PR TITLE
Fix byte-compiler warning about free variable `better-jumper-local-mode`

### DIFF
--- a/better-jumper.el
+++ b/better-jumper.el
@@ -486,7 +486,8 @@ Cleans up deleted windows and copies history to newly created windows."
 
 (with-eval-after-load 'evil
   (defadvice evil-set-jump (before better-jumper activate)
-    (when (and better-jumper-local-mode better-jumper-use-evil-jump-advice)
+    (when (and (bound-and-true-p better-jumper-local-mode)
+               better-jumper-use-evil-jump-advice)
       (better-jumper-set-jump))))
 
 (push '(better-jumper-struct . writable) window-persistent-parameters)


### PR DESCRIPTION
This warning occurs because the byte-compiler expands `with-eval-after-load` forms at compile time, before the mode is defined (at run-time).

You could alternatively elevate the mode's definition to be read at compile time, by wrapping `better-jumper-local-mode`'s definition in `(eval-and-compile ...)`, or by preventing the `evil-set-jump` advice from being expanded, by using `eval-after-load` instead of `with-eval-after-load`, but I think this is the simplest solution.