### PR TITLE
Require cl-macs to fix byte compiling

### DIFF
--- a/better-jumper.el
+++ b/better-jumper.el
@@ -44,6 +44,7 @@
 ;;; Code:
 
 (require 'seq)
+(require 'cl-macs)
 
 (defgroup better-jumper nil
   "Better jumper configuration options."


### PR DESCRIPTION
At least on Emacs master, better-jumper can't be required if byte compiled without this. Since `cl-defstruct` is used, I believe this should be required anyway, though I don't know which Emacs version `cl-macs` came to be in, so it may require wrapping in a version guard or upping the minimum emacs version.