### PR TITLE
Rename evil--jumps-jumping-backward to evil--jumps-jump-command

### DIFF
--- a/better-jumper.el
+++ b/better-jumper.el
@@ -298,7 +298,7 @@ Uses current context if CONTEXT is nil."
                (marker (gethash marker-key marker-table)))
           (setq better-jumper--jumping t)
           (when better-jumper-use-evil-jump-advice
-            (setq evil--jumps-jumping-backward t))
+            (setq evil--jumps-jump-command t))
           (if (string-match-p better-jumper--buffer-targets file-name)
               (switch-to-buffer file-name)
             (find-file file-name))


### PR DESCRIPTION
Commit 9cdd55b [0] in evil renamed evil--jumps-jumping-backward to evil--jumps-jump-command, along with some other refactoring. This causes better-jumper to cycle through the last two entries in a loop. Fix it by setting evil--jumps-jump-command instead.

[0] https://github.com/emacs-evil/evil/commit/9cdd55bff8294683b8a37383240430c02445e6fa