### PR TITLE
Add dynamic jump history segregation with user function

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -129,6 +129,28 @@ This number dictates how many of the most recent buffers should have their jump
 state saved to the savehist file when savehist is enabled the the context is set
 to `'buffer`.
 
+#### History Grouping (`better-jumper-history-group-function`)
+
+When set to a function, enables segregating jump histories based on the
+function's return value. The function is called to get a string key for the
+current context, and each unique key gets its own independent jump history. When
+the function returns `nil`, a single shared history is used. This allows dynamic
+grouping by workspace, project, or any other criteria.
+
+```elisp
+;; Always group by perspective
+(setq better-jumper-history-group-function #'persp-current-name)
+
+;; Conditionally group by project (nil when no project)
+(setq better-jumper-history-group-function #'projectile-project-root)
+
+;; Context-aware grouping
+(setq better-jumper-history-group-function
+      (lambda ()
+        (when (string-match-p "work" default-directory)
+          (format "work-%s" (projectile-project-name)))))
+```
+
 # Hooks
 
 #### Pre-jump Hook (`better-jumper-pre-jump-hook`)

--- a/better-jumper.el
+++ b/better-jumper.el
@@ -110,6 +110,15 @@
   :group 'better-jumper
   :type  '(list symbol))
 
+(defcustom better-jumper-history-group-function nil
+  "Function to determine key for segregating jump histories.
+When non-nil, this function will be called to get a key for the current context.
+The function should return a string to use as a hash table key, or nil.
+When the function is nil or returns nil, jumps are stored in a single history."
+  :type '(choice (const :tag "No history segregation" nil)
+                 (function :tag "Function returning history key string or nil"))
+  :group 'better-jumper)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -138,6 +147,9 @@
 
 (defvar-local better-jumper--jump-struct nil
   "Jump struct for current buffer.")
+
+(defvar-local better-jumper--jump-struct-hashtable nil
+  "Hash table of jump structs for current buffer, keyed by history group.")
 
 (defvar-local better-jumper--marker-table nil
   "Marker table for current buffer.")
@@ -185,27 +197,61 @@
 
 (defun better-jumper--get-buffer-struct (&optional buffer)
   "Get current jump struct for BUFFER.
-Creates and sets jump struct if one does not exist. buffer if BUFFER parameter
-is missing."
+Creates and sets jump struct if one does not exist. Uses current buffer
+if BUFFER parameter is missing."
   (let* ((buffer (or buffer (current-buffer)))
-         (jump-struct (buffer-local-value 'better-jumper--jump-struct buffer)))
-    (unless jump-struct
-      (setq jump-struct (better-jumper--find-buffer-struct-savehist buffer))
-      (unless jump-struct
-        (setq jump-struct (make-better-jumper-jump-list-struct))
-        (better-jumper--set-buffer-struct buffer jump-struct)))
-    jump-struct))
+         (key (when better-jumper-history-group-function
+                (funcall better-jumper-history-group-function))))
+    (if key
+        ;; When function returns a key, store multiple histories in a hash table
+        (let* ((jump-struct-hashtable (buffer-local-value 'better-jumper--jump-struct-hashtable buffer))
+               (jump-struct nil))
+          ;; Create hash table if it doesn't exist
+          (unless jump-struct-hashtable
+            (setq jump-struct-hashtable (make-hash-table :test 'equal))
+            (setf (buffer-local-value 'better-jumper--jump-struct-hashtable buffer) jump-struct-hashtable))
+          ;; Get or create jump struct for this key
+          (setq jump-struct (gethash key jump-struct-hashtable))
+          (unless jump-struct
+            (setq jump-struct (make-better-jumper-jump-list-struct))
+            (puthash key jump-struct jump-struct-hashtable))
+          jump-struct)
+      ;; When function is nil or returns nil, use single history
+      (let ((jump-struct (buffer-local-value 'better-jumper--jump-struct buffer)))
+        (unless jump-struct
+          (setq jump-struct (better-jumper--find-buffer-struct-savehist buffer))
+          (unless jump-struct
+            (setq jump-struct (make-better-jumper-jump-list-struct))
+            (better-jumper--set-buffer-struct buffer jump-struct)))
+        jump-struct))))
 
 (defun better-jumper--get-window-struct (&optional window)
   "Get current jump struct for WINDOW.
-Creates and sets jump struct if one does not exist. buffer if WINDOW parameter
-is missing."
+Creates and sets jump struct if one does not exist. Use current window
+if WINDOW parameter is missing."
   (let* ((window (or window (frame-selected-window)))
-         (jump-struct (window-parameter window 'better-jumper-struct)))
-    (unless jump-struct
-      (setq jump-struct (make-better-jumper-jump-list-struct))
-      (better-jumper--set-struct window jump-struct))
-    jump-struct))
+         (key (when better-jumper-history-group-function
+                (funcall better-jumper-history-group-function))))
+    (if key
+        ;; When function returns a key, store multiple histories in a hash table
+        (let* ((jump-struct-hashtable (window-parameter window 'better-jumper-struct-hashtable))
+               (jump-struct nil))
+          ;; Create hash table if it doesn't exist
+          (unless jump-struct-hashtable
+            (setq jump-struct-hashtable (make-hash-table :test 'equal))
+            (set-window-parameter window 'better-jumper-struct-hashtable jump-struct-hashtable))
+          ;; Get or create jump struct for this key
+          (setq jump-struct (gethash key jump-struct-hashtable))
+          (unless jump-struct
+            (setq jump-struct (make-better-jumper-jump-list-struct))
+            (puthash key jump-struct jump-struct-hashtable))
+          jump-struct)
+      ;; When function is nil or returns nil, use single history
+      (let ((jump-struct (window-parameter window 'better-jumper-struct)))
+        (unless jump-struct
+          (setq jump-struct (make-better-jumper-jump-list-struct))
+          (better-jumper--set-struct window jump-struct))
+        jump-struct))))
 
 (defun better-jumper--get-struct (&optional context)
   "Get current jump struct for CONTEXT.


### PR DESCRIPTION
# Add dynamic jump history segregation

This PR adds the ability to dynamically segregate jump histories based on a user-defined function, enabling users to maintain separate jump lists for different contexts while allowing seamless switching between grouped and ungrouped behavior.

# Changes

- New configuration: better-jumper-history-group-function - when set to a function, enables dynamic history segregation
- Context-aware grouping: The function is called to get a string key for the current context, or can return nil to disable grouping
- Enhanced data structures: Each buffer/window can store multiple jump histories in a hash table when grouping is active
- Dynamic behavior: Seamlessly switches between single history and grouped histories based on function return value

# Usage Examples

```elisp
;; Always group by perspective
(setq better-jumper-history-group-function #'persp-current-name)

;; Conditionally group by project (nil when no project)
(setq better-jumper-history-group-function #'projectile-project-root)

;; Context-aware grouping
(setq better-jumper-history-group-function
      (lambda ()
        (when (string-match-p "work" default-directory)
          (format "work-%s" (projectile-project-name)))))
```

# Key Features

- Dynamic switching: Function can return nil to disable grouping in specific contexts
- Isolated histories: Each group maintains its own independent jump history
- Automatic management: Hash tables are created and managed transparently
- Backward compatible: Existing configurations continue to work unchanged

This enables context-aware workflow organization where jump histories are automatically segregated when needed and unified when grouping isn't appropriate.
