### PR TITLE
Add indirect buffer support

### DIFF
--- a/better-jumper.el
+++ b/better-jumper.el
@@ -154,6 +154,27 @@
     (setf (better-jumper-jump-list-struct-ring struct-copy) (ring-copy jump-list))
     struct-copy))
 
+(defun better-jumper--copy-struct-for-savehist (struct)
+  "Return a copy of STRUCT safe for savehist (strips buffer objects)."
+  (let ((jump-list (better-jumper--get-struct-jump-list struct))
+        (struct-copy (make-better-jumper-jump-list-struct)))
+    (setf (better-jumper-jump-list-struct-idx struct-copy) (better-jumper-jump-list-struct-idx struct))
+    (setf (better-jumper-jump-list-struct-ring struct-copy) (make-ring better-jumper-max-length))
+    ;; Copy jumps but strip buffer objects (4th element)
+    (dotimes (i (ring-length jump-list))
+      (let* ((jump (ring-ref jump-list i))
+             (savehist-jump (list (nth 0 jump) (nth 1 jump) (nth 2 jump))))
+        (ring-insert (better-jumper-jump-list-struct-ring struct-copy) savehist-jump)))
+    struct-copy))
+
+(defun better-jumper--get-buffer-file-name (&optional buffer)
+  "Get file name for BUFFER, supporting indirect buffers.
+Uses current buffer if BUFFER is nil."
+  (let ((buf (or buffer (current-buffer))))
+    (or (buffer-file-name buf)
+        (and (buffer-base-buffer buf)
+             (buffer-file-name (buffer-base-buffer buf))))))
+
 (defun better-jumper--get-current-context ()
   "Get current context item. Either current window or buffer."
   (pcase better-jumper-context
@@ -176,7 +197,7 @@
 
 (defun better-jumper--find-buffer-struct-savehist (buffer)
   "Look for BUFFER jump history in savehist variable."
-  (let ((filename (buffer-file-name buffer)))
+  (let ((filename (better-jumper--get-buffer-file-name buffer)))
     (when filename
       (nth 1
            (seq-find (lambda (e)
@@ -295,13 +316,21 @@ Uses current context if CONTEXT is nil."
                (file-name (nth 0 place))
                (pos (nth 1 place))
                (marker-key (nth 2 place))
+               (buffer-obj (when (>= (length place) 4) (nth 3 place)))
                (marker (gethash marker-key marker-table)))
           (setq better-jumper--jumping t)
           (when better-jumper-use-evil-jump-advice
             (setq evil--jumps-jump-command t))
-          (if (string-match-p better-jumper--buffer-targets file-name)
-              (switch-to-buffer file-name)
-            (find-file file-name))
+          (cond
+           ;; Try to use stored buffer object if valid
+           ((and buffer-obj (buffer-live-p buffer-obj))
+            (switch-to-buffer buffer-obj))
+           ;; Fallback to buffer name matching for special buffers
+           ((string-match-p better-jumper--buffer-targets file-name)
+            (switch-to-buffer file-name))
+           ;; Fallback to find-file for regular files
+           (t
+            (find-file file-name)))
           (if (and marker (marker-position marker))
               (goto-char marker)
             (goto-char pos)
@@ -315,7 +344,7 @@ Uses current context if CONTEXT is nil."
 Uses current context if CONTEXT is nil."
   (let ((jump-list (better-jumper--get-jump-list context))
         (marker-table (better-jumper--get-marker-table context))
-        (file-name (buffer-file-name))
+        (file-name (better-jumper--get-buffer-file-name))
         (buffer-name (buffer-name))
         (current-marker (point-marker))
         (current-point (point))
@@ -337,7 +366,7 @@ Uses current context if CONTEXT is nil."
                      (equal first-file-name file-name))
           (let ((key (better-jumper--make-key)))
             (puthash key current-marker marker-table)
-            (ring-insert jump-list `(,file-name ,current-point ,key))))))))
+            (ring-insert jump-list `(,file-name ,current-point ,key ,(current-buffer)))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;   PUBLIC FUNCTIONS    ;;;
@@ -506,7 +535,7 @@ Cleans up deleted windows and copies history to newly created windows."
       (let* ((buffer-name (nth 0 entry))
              (struct (nth 1 entry))
              (found-buffer (seq-find (lambda (b)
-                                       (or (eq buffer-name (buffer-file-name b))
+                                       (or (eq buffer-name (better-jumper--get-buffer-file-name b))
                                            (eq buffer-name (buffer-name b))))
                                      (buffer-list))))
         (when found-buffer
@@ -516,7 +545,7 @@ Cleans up deleted windows and copies history to newly created windows."
 
 (defun better-jumper--is-local-file-buffer (buffer)
   "Return non-nil if BUFFER refers to a local file that exists."
-  (let ((filename (buffer-file-name buffer)))
+  (let ((filename (better-jumper--get-buffer-file-name buffer)))
     (and filename
          (not (file-remote-p filename))
          (file-exists-p filename))))
@@ -532,8 +561,8 @@ Cleans up deleted windows and copies history to newly created windows."
                     better-jumper-buffer-savehist-size)))
       (setq better-jumper-savehist
             (mapcar #'(lambda (buffer)
-                        (let ((filename (buffer-file-name buffer))
-                              (struct (better-jumper--copy-struct (better-jumper--get-buffer-struct buffer))))
+                        (let ((filename (better-jumper--get-buffer-file-name buffer))
+                              (struct (better-jumper--copy-struct-for-savehist (better-jumper--get-buffer-struct buffer))))
                           (list filename struct)))
                     buffers)))))
 


### PR DESCRIPTION
Adds comprehensive support for indirect buffers in better-jumper. Previously, indirect buffers (created with clone-indirect-buffer) would not record jumps properly because buffer-file-name returns nil for indirect buffers.

# Changes
There are 2 main changes. 

The first one is the following, to add minimal working jumps in indirect buffers, and has the least impact:
- Enhanced buffer file name detection: Added better-jumper--get-buffer-file-name helper that falls back to the base buffer's filename for indirect buffers

The second is a more complex change, that's especially useful when using better-jumper-context 'window. It allows you to remember in which indirect buffer you were, so when you jump back you'll end up in the correct buffer instead of always jumping to the base buffer:
- Smart buffer switching: Jump entries now store buffer objects to preserve the distinction between base and indirect buffers
- Graceful fallback: When jumping to a deleted buffer, automatically falls back to opening the base file
- Savehist compatibility: Buffer objects are safely stripped when persisting jump history to disk

# Behavior

## Before

- Indirect buffers like file.org<2> would not add entries to jump history
- Jump navigation was broken in indirect buffers

## After

- Window mode: Indirect buffers contribute to window-specific jump history and jumping preserves buffer context (indirect vs base)
- Buffer mode: Indirect buffers can record jumps properly
  - *After the using clone-indirect-buffer, the buffer-local jump struct is shared between the base buffer and the indirect buffer. This means jump history is shared between the two. This may not be the desired behaviour -> Should I change this?*
- Robust: Handles deleted indirect buffers gracefully by falling back to the base file

Tests

- Create indirect buffer with clone-indirect-buffer
- Navigate and set jumps in both base and indirect buffers
- Verify jump history is properly recorded and shared (buffer mode) or isolated (window mode)
- Test jumping between base and indirect buffers preserves correct buffer context
  - Verify fallback behavior when indirect buffer is deleted
